### PR TITLE
[issue #7] Refactored things a bit.

### DIFF
--- a/template.go
+++ b/template.go
@@ -304,6 +304,7 @@ func New(name string, options ...anOption) (*Template, error) {
 	// We install the users handlers, this does mean that the user can overwrite our
 	// Helpers
 	t.helpers = template.FuncMap{
+		"buildMimeTypeFiles":  t.BuildMimeTypeFile,
 		"buildJSFiles":        t.BuildJSFile,
 		"buildLinkToJSFiles":  t.LinkToAndBuildJSFile,
 		"buildCSSFiles":       t.BuildCSSFile,


### PR DESCRIPTION
The original intent of the issue was to get a more generic Bundle assets
of this type function that people can use. That was created, but I did
not do so for the Link variant because it turns out to be more
complicated with differnet `rel` for each link tag and tags themselfs
can be different `link` v.s. `script`. Figured, that it is fine not to
have the additional convience function because could build them to there
needs with the Generic build and Bundle function.